### PR TITLE
fix: show first token

### DIFF
--- a/tilert/generate.py
+++ b/tilert/generate.py
@@ -136,7 +136,7 @@ class ShowHandsGenerator:
             tokens[0, cur_pos_val] = next_token
             finished |= torch.logical_and(~prompt_mask[0, cur_pos_val], next_token == self.eos_id)
             prev_pos = cur_pos_val
-            if cur_pos_val > prompt_len:
+            if cur_pos_val >= prompt_len:
                 decoded_tokens = self.tokenizer.decode(
                     [next_token.item()], skip_special_tokens=True
                 )


### PR DESCRIPTION
Fixed an issue where the first token was not being output when using the interactive mode of generate.py.

Before:

<img width="513" height="63" alt="image" src="https://github.com/user-attachments/assets/64ef86be-f0b0-4268-992a-4e5a59d3d952" />

Now:

<img width="503" height="56" alt="image" src="https://github.com/user-attachments/assets/d5f50666-486f-4d6e-b2dc-a0564022ab8b" />
